### PR TITLE
Replace index page with a placeholder

### DIFF
--- a/src/components/molecules/placeholderLinks.js
+++ b/src/components/molecules/placeholderLinks.js
@@ -2,7 +2,6 @@ import React from 'react';
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
 
-
 const PurpleButton = styled.button`
   background: #2C358F;
   border: none;
@@ -16,35 +15,36 @@ const PurpleButton = styled.button`
   width: 280px;
 `;
 
-const Button = ({ color, text }) => {
-    return (
-      <PurpleButton>{text}</PurpleButton>
-    );
-};
+const Button = ({ text }) => (
+  <PurpleButton>{text}</PurpleButton>
+);
 
-Button.defaultProps = {
-  color: '',
-  type: '',
-  onClick: () => {},
-};
 const Container = styled.div`
   align-items: center;
   justify-content: center;
   display: flex;
   flex-direction: column;
   margin-bottom: 24px;
-`
+`;
 export const PlaceholderLinks = styled.ul`
   list-style: none;
-`
+`;
 
-export const PlaceholderLink = ({text, href}) => {
+export const PlaceholderLink = ({ text, href }) => (
+  <Container>
+    <li>
+      <a href={href}>
+        <Button type="button" color="purple" text={text} />
+      </a>
+    </li>
+  </Container>
+);
 
-    return <Container>
-             <li>
-               <a href={href}>
-                 <Button type="button" color="purple" text={text}/>
-               </a>
-             </li>
-           </Container>
-}
+PlaceholderLink.propTypes = {
+  text: PropTypes.string.isRequired,
+  href: PropTypes.string.isRequired,
+};
+
+Button.propTypes = {
+  text: PropTypes.string.isRequired,
+};

--- a/src/components/molecules/placeholderLinks.js
+++ b/src/components/molecules/placeholderLinks.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import styled from 'styled-components';
+import PropTypes from 'prop-types';
+
+
+const PurpleButton = styled.button`
+  background: #2C358F;
+  border: none;
+  font-weight: bold;
+  font-size: 20px;
+  text-align: center;
+  text-transform: uppercase;
+  font-family: urw-din;
+  color: #FFFFFF;
+  height: 60px;
+  width: 280px;
+`;
+
+const Button = ({ color, text }) => {
+    return (
+      <PurpleButton>{text}</PurpleButton>
+    );
+};
+
+Button.defaultProps = {
+  color: '',
+  type: '',
+  onClick: () => {},
+};
+const Container = styled.div`
+  align-items: center;
+  justify-content: center;
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 24px;
+`
+export const PlaceholderLinks = styled.ul`
+  list-style: none;
+`
+
+export const PlaceholderLink = ({text, href}) => {
+
+    return <Container>
+             <li>
+               <a href={href}>
+                 <Button type="button" color="purple" text={text}/>
+               </a>
+             </li>
+           </Container>
+}

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,6 +1,64 @@
 import React from 'react';
-import Endorsements from './endorsements';
+import PropTypes from 'prop-types';
+import { graphql } from 'gatsby';
+import Layout from '../components/templates/layout';
+import HomePageLogo from '../components/molecules/homePageLogo';
+import BottomSection from '../components/organisms/BottomSection';
+import HomeHeadlineSection from '../components/organisms/HomeHeadlineSection';
 
-const IndexPage = () => <Endorsements />;
+import footerImage from '../images/home-images/footer-image.png';
+import Button from '../components/atoms/button';
+import {PlaceholderLinks, PlaceholderLink} from '../components/molecules/placeholderLinks';
+
+import homeImageA from '../images/home-images/home-image-a.png';
+import homeImageB from '../images/home-images/home-image-b.png';
+import homeImageC from '../images/home-images/home-image-c.png';
+
+const IndexPage = ({ data }) => {
+  const homepageData = data.allContentfulHomepageData.edges;
+
+  return (
+    <>
+      <Layout>
+        <HomePageLogo />
+        {homepageData.map((homeData) => {
+          const { title, simpleDescription, id } = homeData.node;
+          return (
+            <HomeHeadlineSection
+              title={title}
+              description={simpleDescription.simpleDescription}
+              id={id}
+            />
+          );
+        })}
+        <PlaceholderLinks>
+          <PlaceholderLink text="Sign Up" href="https://www.google.com/url?q=https%3A%2F%2Fnbk.inthefight.org%2Fjoinus&sa=D&sntz=1&usg=AFQjCNHMbRtqUWbxzfTS_XspVULOupVc3Q" />
+          <PlaceholderLink text="Events" href="https://www.google.com/url?q=https%3A%2F%2Fwww.mobilize.us%2Finthefight%2F&sa=D&sntz=1&usg=AFQjCNHOq_AcEGktJAG9m-jgt-UpCBmpmw" />
+          {/* TODO: <PlaceholderLink text="Resources" href="/resources" /> */}
+        </PlaceholderLinks>
+      </Layout>
+    </>
+  );
+};
+
+IndexPage.propTypes = {
+  data: PropTypes.node.isRequired,
+};
 
 export default IndexPage;
+
+export const homePageQuery = graphql`
+  query homePageQuery {
+    allContentfulHomepageData {
+      edges {
+        node {
+          id
+          title
+          simpleDescription {
+            simpleDescription
+          }
+        }
+      }
+    }
+  }
+`;

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -3,16 +3,9 @@ import PropTypes from 'prop-types';
 import { graphql } from 'gatsby';
 import Layout from '../components/templates/layout';
 import HomePageLogo from '../components/molecules/homePageLogo';
-import BottomSection from '../components/organisms/BottomSection';
 import HomeHeadlineSection from '../components/organisms/HomeHeadlineSection';
 
-import footerImage from '../images/home-images/footer-image.png';
-import Button from '../components/atoms/button';
-import {PlaceholderLinks, PlaceholderLink} from '../components/molecules/placeholderLinks';
-
-import homeImageA from '../images/home-images/home-image-a.png';
-import homeImageB from '../images/home-images/home-image-b.png';
-import homeImageC from '../images/home-images/home-image-c.png';
+import { PlaceholderLinks, PlaceholderLink } from '../components/molecules/placeholderLinks';
 
 const IndexPage = ({ data }) => {
   const homepageData = data.allContentfulHomepageData.edges;


### PR DESCRIPTION
The plan deploy the endorsement questionaire at a subdomain
(i.e., endorsements.inthefight.org) ran into trouble with tsl
encryption. The issue is that we need to serve the root domain
certificate from inthefight.org, and with two hosts, that's, while
certainly not impossible, non-trivial.

So instead, we mirror the main points of the current placeholder page,
so we can deploy all at once