### PR TITLE
Endorsements submission message

### DIFF
--- a/src/components/atoms/submitMsg.js
+++ b/src/components/atoms/submitMsg.js
@@ -6,11 +6,13 @@ import {
   FormPresubmit,
 } from '../../styles/form-styles';
 
-const SubmitMsg = ({ submitted, msg, errMsg }) => {
+const SubmitMsg = ({ submitted, successMsg, errMsg, pendingMsg }) => {
   if (submitted.status === 'trouble') {
     return <FormTroubleMsg>{errMsg}</FormTroubleMsg>;
+  } if (submitted.status === 'pending') {
+    return <FormSubmitMsg>{pendingMsg}</FormSubmitMsg>;
   } if (submitted.status === 'submitted') {
-    return <FormSubmitMsg>{msg}</FormSubmitMsg>;
+    return <FormSubmitMsg>{successMsg}</FormSubmitMsg>;
   }
   return <FormPresubmit />;
 };
@@ -18,7 +20,8 @@ const SubmitMsg = ({ submitted, msg, errMsg }) => {
 export default SubmitMsg;
 
 SubmitMsg.propTypes = {
-  msg: PropTypes.string.isRequired,
+  successMsg: PropTypes.string.isRequired,
+  pendingMsg: PropTypes.string.isRequired,
   errMsg: PropTypes.string.isRequired,
   submitted: PropTypes.bool.isRequired,
 };

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -18,4 +18,13 @@ function makeSlug(node, prefix) {
   return slg;
 }
 
+// Explicitly igonre an argument, with warnings turned off
+// Useful in promises, where we sometimes need a handler to take an argument, but
+// don't have anything in particular to do with it
+
+/* eslint-disable no-unused-vars */
+function discard(val) {}
+/* eslint-enable no-unused-vars */
+
 module.exports.makeSlug = makeSlug;
+module.exports.discard = discard;

--- a/src/pages/endorsement-questionnaire.js
+++ b/src/pages/endorsement-questionnaire.js
@@ -12,7 +12,6 @@ import Bool from '../components/molecules/Bool';
 import FormTextInput from '../components/atoms/FormTextInput';
 import FormTextArea from '../components/atoms/FormTextArea';
 import SubmitMsg from '../components/atoms/submitMsg';
-import discard from '../lib/utils';
 
 import {
   EndorsementIntro,
@@ -93,20 +92,17 @@ const Endorsements = () => {
 
   const handleSubmit = (e) => {
     e.preventDefault();
+    e.persist();
 
+    setSubmitted({ status: 'pending' });
     client.getSpace(data.site.siteMetadata.tokens.spaceId)
       .then((space) => space.getEnvironment('master'))
-      .then((environment) => {
-        setSubmitted({ status: 'pending' });
-        return environment.createEntry('candidateQuestionnaires', contentfulize(questionnaire));
-      })
-      .then((res) => {
-        if (res.fields) {
-          setSubmitted({ status: 'submitted' });
-        } else {
-          setSubmitted({ status: 'trouble' });
-        }
-      }, (err) => { discard(err); setSubmitted({ status: 'trouble' }); });
+      .then((environment) => environment.createEntry('candidateQuestionnaires', contentfulize(questionnaire)))
+      .catch(() => setSubmitted({ status: 'trouble' }))
+      .finally(() => {
+        setSubmitted({ status: 'submitted' });
+        e.target.reset();
+      });
   };
 
   const setField = (event) => {

--- a/src/pages/endorsement-questionnaire.js
+++ b/src/pages/endorsement-questionnaire.js
@@ -12,6 +12,7 @@ import Bool from '../components/molecules/Bool';
 import FormTextInput from '../components/atoms/FormTextInput';
 import FormTextArea from '../components/atoms/FormTextArea';
 import SubmitMsg from '../components/atoms/submitMsg';
+import discard from '../lib/utils';
 
 import {
   EndorsementIntro,
@@ -92,19 +93,20 @@ const Endorsements = () => {
 
   const handleSubmit = (e) => {
     e.preventDefault();
+
     client.getSpace(data.site.siteMetadata.tokens.spaceId)
       .then((space) => space.getEnvironment('master'))
-      .then((environment) => environment.createEntry('candidateQuestionnaires', contentfulize(questionnaire)),
-        setSubmitted({ status: 'trouble' }))
-      .then(setSubmitted({ status: 'pending' }))
+      .then((environment) => {
+        setSubmitted({ status: 'pending' });
+        return environment.createEntry('candidateQuestionnaires', contentfulize(questionnaire));
+      })
       .then((res) => {
         if (res.fields) {
-          setSubmitted({ status: 'submitted' })
-          debugger
+          setSubmitted({ status: 'submitted' });
         } else {
-          setSubmitted({ status: 'trouble' })
+          setSubmitted({ status: 'trouble' });
         }
-      }, setSubmitted({ status: 'trouble' }))
+      }, (err) => { discard(err); setSubmitted({ status: 'trouble' }); });
   };
 
   const setField = (event) => {

--- a/src/pages/endorsement-questionnaire.js
+++ b/src/pages/endorsement-questionnaire.js
@@ -75,13 +75,13 @@ const Endorsements = () => {
       query {
           site {
           siteMetadata {
-              tokens {
+            tokens {
               accessToken
               spaceId
               apiKey
-              }
+            }
           }
-          }
+        }
       }
     `,
   );
@@ -96,8 +96,15 @@ const Endorsements = () => {
       .then((space) => space.getEnvironment('master'))
       .then((environment) => environment.createEntry('candidateQuestionnaires', contentfulize(questionnaire)),
         setSubmitted({ status: 'trouble' }))
-      .then(e.target.reset())
-      .then(setSubmitted({ status: 'submitted' }), () => { setSubmitted({ status: 'trouble' }); });
+      .then(setSubmitted({ status: 'pending' }))
+      .then((res) => {
+        if (res.fields) {
+          setSubmitted({ status: 'submitted' })
+          debugger
+        } else {
+          setSubmitted({ status: 'trouble' })
+        }
+      }, setSubmitted({ status: 'trouble' }))
   };
 
   const setField = (event) => {
@@ -377,8 +384,9 @@ const Endorsements = () => {
         </FormNumberedFields>
         <SubmitMsg
           submitted={submitted}
-          msg="Thank you! Your answers have been submitted."
+          successMsg="Thank you! Your answers have been submitted."
           errMsg="There was a problem submitting the form"
+          pendingMsg="Submitting your answer..."
         />
       </Form>
     </Layout>


### PR DESCRIPTION
Delay the submit message until actual success.

Hand-waving a bit here, but it seems like strange things happen to Promise control flow when the handlers don't take an argument. So I think what was going on with our "catch" branch was essentially the same issue we were seeing earlier with premature submitted: when a handler is a statement, rather than a function, it runs as soon as possible, rather than waiting for the Promise to settle.