### PR TITLE
Events from Mobilize

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25903,6 +25903,14 @@
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
+    "react-loader-spinner": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/react-loader-spinner/-/react-loader-spinner-4.0.0.tgz",
+      "integrity": "sha512-RU2vpEej6G4ECei0h3q6bgLU10of9Lw5O+4AwF/mtkrX5oY20Sh/AxoPJ7etbrs/7Q3u4jN5qwCwGLRKCHpk6g==",
+      "requires": {
+        "prop-types": "^15.7.2"
+      }
+    },
     "react-modal": {
       "version": "3.12.1",
       "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.12.1.tgz",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "version": "0.1.0",
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
   "dependencies": {
+    "axios": "^0.21.1",
     "babel-plugin-styled-components": "^1.11.1",
     "babel-plugin-transform-runtime": "^6.23.0",
     "babel-polyfill": "^6.26.0",
@@ -43,6 +44,7 @@
     "react": "^16.14.0",
     "react-dom": "^16.14.0",
     "react-helmet": "^6.1.0",
+    "react-loader-spinner": "^4.0.0",
     "react-modal": "^3.12.1",
     "regenerator-runtime": "^0.13.7",
     "styled-components": "^5.2.0",

--- a/src/components/atoms/dateField.js
+++ b/src/components/atoms/dateField.js
@@ -21,6 +21,8 @@ const DateField = ({ date }) => {
     year: 'numeric',
     month: 'long',
     day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
   };
   const formattedDate = new Date(date).toLocaleDateString('en-US', options);
 
@@ -35,7 +37,7 @@ const DateField = ({ date }) => {
 };
 
 DateField.propTypes = {
-  date: PropTypes.string.isRequired,
+  date: PropTypes.instanceOf(Date).isRequired,
 };
 
 export default DateField;

--- a/src/components/atoms/location.js
+++ b/src/components/atoms/location.js
@@ -15,14 +15,17 @@ const LocationIcon = styled.img`
   margin: 7px 10px 0 0;
   `;
 
-const Location = ({ location, virtual }) => (
-  <LocationContainer>
-    <LocationIcon src={locationPin} alt="Location" />
-    <p data-testid="date-field">
-      {` ${virtual ? 'Virtual event' : ''} -  ${location}`}
-    </p>
-  </LocationContainer>
-);
+const Location = ({ location, virtual }) => {
+  const virtualOrLocation = virtual ? 'Virtual event' : location;
+  return (
+    <LocationContainer>
+      <LocationIcon src={locationPin} alt="Location" />
+      <p data-testid="date-field">
+        {virtualOrLocation}
+      </p>
+    </LocationContainer>
+  );
+};
 
 Location.propTypes = {
   location: PropTypes.string.isRequired,

--- a/src/pages/events.js
+++ b/src/pages/events.js
@@ -1,124 +1,143 @@
-import React, { useState } from 'react';
-import PropTypes from 'prop-types';
-import { graphql } from 'gatsby';
+import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
+import axios from 'axios';
 
-import EventsModal from '../components/organisms/eventsModal';
+import Loader from 'react-loader-spinner';
+import 'react-loader-spinner/dist/loader/css/react-spinner-loader.css';
+
 import DateField from '../components/atoms/dateField';
 import Location from '../components/atoms/location';
 import Layout from '../components/templates/layout';
 import Button from '../components/atoms/button';
+import logo from '../images/logos/ITF-home-logo.png';
 
 const EventContainer = styled.div`
-    display: flex;
-    flex-direction: row;
-    justif-content: flex-start;
-    margin-top: 50px;
-  `;
+  display: flex;
+  flex-direction: row;
+  justif-content: flex-start;
+  margin-top: 50px;
+`;
+
+const LayoutContainer = styled.div`
+  min-height: 600px;
+  margin-left: 50%;
+`;
 
 const EventTitle = styled.h2`
-    font-family: Gelo;
-    font-weight: normal;
-  `;
+  font-family: Gelo;
+  font-weight: normal;
+`;
 
 const StyledImage = styled.img`
-    margin-left: 50px;
-  `;
+  margin-left: 50px;
+  height: 200px;
+  width: 350px;
+`;
 
 const EventInfoContainer = styled.div`
-    margin-left: 70px;
-    width: 700px
-  `;
+  margin-left: 70px;
+  width: 700px
+`;
 
 const StyledDescription = styled.p`
   color: #000001cc;
 `;
 
-const Events = ({ data }) => {
-  const [modalIsOpen, setModalIsOpen] = useState(false);
-  const eventsData = data.allContentfulEvents.edges;
-  const [selectedEvent, setSelectedEvent] = useState('');
+const Events = () => {
+  const [events, setEvents] = useState([]);
+  const organizationId = 2828; // Hard-coded In The Fight Mobilize id
+  const mobilizeUrl = `https://api.mobilize.us/v1/organizations/${organizationId}/events?per_page=50`;
 
-  const openModal = (currentEvent) => {
-    setModalIsOpen(true);
-    setSelectedEvent(currentEvent);
+  useEffect(() => {
+    let responseEvents = [];
+    const getEvents = (url) => {
+      if (events.length === 0) {
+        axios.get(url)
+          .then((response) => {
+            responseEvents.push(response.data.data);
+            responseEvents = responseEvents.flat();
+            if (response.data.next) {
+              getEvents(response.data.next);
+            } else {
+              setEvents(responseEvents);
+            }
+          })
+          .catch((error) => {
+            /* eslint-disable no-console */
+            console.log(error);
+            /* eslint-enable no-console */
+          });
+      }
+    };
+    getEvents(mobilizeUrl);
+  }, [mobilizeUrl, events]);
+
+  function toDate(ts) {
+    return new Date(ts * 1000); // convert Mobilize Unix seconds to milliseconds
+  }
+
+  const formatAndOrganizeEvents = (eventsToFormat) => {
+    const formattedEvents = [];
+    eventsToFormat.forEach((e) => {
+      e.timeslots.forEach((t) => {
+        const locationString = e.location?.locality && e.location?.region ? `${e?.location?.locality}, ${e?.location?.region}` : '';
+        if ((toDate(t.end_date)) > Date.now()) {
+          formattedEvents.push({
+            start_date: toDate(t.start_date),
+            end_date: toDate(t.end_date),
+            title: e.title,
+            description: e.description,
+            location: locationString,
+            is_virtual: e.is_virtual,
+            featured_image_url: e.featured_image_url,
+            browser_url: e.browser_url,
+          });
+        }
+      });
+    });
+
+    const sorter = (a, b) => a.start_date.getTime() - b.start_date.getTime();
+    return formattedEvents.sort(sorter);
   };
 
-  const closeModal = (event) => {
-    setModalIsOpen(false);
-    setSelectedEvent(event.node);
+  const openInNewTab = (url) => {
+    const newWindow = window.open(url, '_blank', 'noopener,noreferrer');
+    if (newWindow) newWindow.opener = null;
   };
 
+  /* eslint-disable no-shadow */
+  const displayEvents = () => {
+    if (events.length > 0) {
+      return formatAndOrganizeEvents(events).map((e) => (
+        <EventContainer key={e.id} id={e.id}>
+          <StyledImage
+            src={e.featured_image_url}
+            onError={(e) => { e.target.src = logo; }}
+            alt="event image"
+          />
+          <EventInfoContainer>
+            <EventTitle>{e.title}</EventTitle>
+            <h3>About this event</h3>
+            <DateField date={e.start_date} />
+            <Location location={e.location} virtual={e.is_virtual} />
+            <StyledDescription>{e.description}</StyledDescription>
+            <Button text="Sign up for this event" color="purple" onClick={() => openInNewTab(e.browser_url)} />
+          </EventInfoContainer>
+        </EventContainer>
+      ));
+    }
+    return (
+      <LayoutContainer>
+        <Loader type="TailSpin" color="#2c358f" height={80} width={80} />
+      </LayoutContainer>
+    );
+  };
+  /* eslint-enable no-shadow */
   return (
     <Layout>
-      {eventsData.map((event) => {
-        const {
-          datetime,
-          description,
-          id,
-          location,
-          media,
-          title,
-          virtual,
-        } = event.node;
-
-        return (
-          <EventContainer key={id}>
-            <StyledImage src={media.file.url} alt="event image" />
-            <EventInfoContainer>
-              <EventTitle>{title}</EventTitle>
-              <h3>About this event</h3>
-              <DateField date={datetime} />
-              <Location location={location} virtual={virtual} />
-              <StyledDescription>{description.description}</StyledDescription>
-              <Button text="Sign up for this event" color="purple" onClick={() => openModal(event.node)} />
-            </EventInfoContainer>
-          </EventContainer>
-        );
-      })}
-      {selectedEvent
-        ? (
-          <EventsModal
-            isOpen={modalIsOpen}
-            onRequestClose={closeModal}
-            title={selectedEvent.title}
-            description={selectedEvent.description.description}
-            date={selectedEvent.datetime}
-            virtual={selectedEvent.virtual}
-            location={selectedEvent.location}
-          />
-        )
-        : ''}
+      {displayEvents()}
     </Layout>
   );
 };
 
-Events.propTypes = {
-  data: PropTypes.node.isRequired,
-};
-
 export default Events;
-
-export const eventsQuery = graphql`
-    query eventsQuery {
-      allContentfulEvents {
-        edges {
-          node {
-            id
-            title
-            datetime
-            location
-            virtual
-            description {
-              description
-            }
-            media {
-              file {
-                url
-              }
-            }
-          }
-        }  
-      }
-    }
-  `;

--- a/src/styles/global-styles.css
+++ b/src/styles/global-styles.css
@@ -82,6 +82,3 @@ h1 {
   font-size: 48px;
 }
 
-.nav-wrapper {
-  visibility: hidden;
-}

--- a/tests/atoms/__snapshots__/dateField.test.js.snap
+++ b/tests/atoms/__snapshots__/dateField.test.js.snap
@@ -16,7 +16,7 @@ Object {
         <p
           data-testid="date-field"
         >
-          Friday, March 20, 2020
+          Friday, March 20, 2020, 12:00 AM
         </p>
       </div>
     </div>
@@ -33,7 +33,7 @@ Object {
       <p
         data-testid="date-field"
       >
-        Friday, March 20, 2020
+        Friday, March 20, 2020, 12:00 AM
       </p>
     </div>
   </div>,


### PR DESCRIPTION
This refactors the events page to get events from mobilize as opposed
to contenteful, and removes unnecessary modal features.
Currently all recurrences of any event is displayed, as long as it is in the future
 Co-authored: @zopa 
Resolves #25 